### PR TITLE
Tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.3",
   "description": "angular-hmr: Hot Module Replacement for Webpack and Angular by @AngularClass",
   "main": "dist/index.js",
+  "sideEffects": false,
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -32,6 +33,5 @@
     "zone.js": "^0.8.12",
     "webpack": "3"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs",
+    "module": "ES2015",
     "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Currently, the module does not get tree shaken in prod builds, even when the dead code is eliminated by webpack. Specifying sideEffects flag in package.json and targeting es2015 modules will allow webpack to tree shake this module completely in prod builds

this fixes #85 