### PR TITLE
Compatibility changes for Angular 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@angularclass/hmr",
-  "version": "2.1.4",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angularclass/hmr",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "angular-hmr: Hot Module Replacement for Webpack and Angular",
   "main": "dist/index.js",
   "sideEffects": false,

--- a/src/hmr.ts
+++ b/src/hmr.ts
@@ -34,7 +34,6 @@ export function hmrModule(MODULE_REF: any, MODULE: any, CONFIG = MODULE_CONFIG) 
       if (MODULE_REF.instance[MODULE_CONFIG['OnDestroy']]) {
         MODULE_REF.instance[MODULE_CONFIG['OnDestroy']](store);
       }
-      MODULE_REF.destroy();
       if (MODULE_REF.instance[MODULE_CONFIG['AfterDestroy']]) {
         MODULE_REF.instance[MODULE_CONFIG['AfterDestroy']](store);
       }


### PR DESCRIPTION
It appears that Angular 11 has some breaking changes with HMR. This causes an error to be thrown when `.destroy()` is called [in `angular-hmr` here](https://github.com/PatrickJS/angular-hmr/blob/master/src/hmr.ts#L37). It appears that the error is originating [from `angular/core` here](https://github.com/angular/angular/blob/master/packages/core/src/render3/ng_module_ref.ts#L80). I am not sure about the cause of the change, but my guess is that Angular is now calling the destroy method itself, before `angular-hmr` would.

Simply removing this call (as suggested in this PR) appears to fix the issue, and HMR appears to be working fine. I have proposed a version bump, as I would guess that this change is breaking for versions of Angular <11.

Unknowns:
- I am not aware of what other implications this change might have (e.g. in use cases other than mine). 
- I upgraded from Angular 9 to 11, so I am not sure with the implications are for Angular 10.